### PR TITLE
Add FPVtune to Telemetry & Logs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ Sensor values and control information are shared via common serial protocols whi
 * [UAVLogViewer](https://github.com/ardupilot/uavlogviewer) - Web application for Ardupilot logs.
 * [OSD-subtitles](https://github.com/kristjanbjarni/osd-subtitles) - Render Blackbox logs to OSD as subtitle for synconous plaback with video file.
 * [Dashware](http://www.dashware.net/dashware-download/) - Closed Source OSD rendering for blackbox logs.
-* [PID-Analyzer](https://github.com/Plasmatree/PID-Analyzer) - Read blackbox and tune PID control variables. 
+* [PID-Analyzer](https://github.com/Plasmatree/PID-Analyzer) - Read blackbox and tune PID control variables.
+* [FPVtune](https://github.com/chugzb/betaflight-pid-autotuning) - Automatic Betaflight PID tuning from blackbox logs. Upload, analyze, get optimized settings in minutes. 
 * [openXsensor](https://github.com/openXsensor/openXsensor) - Convert and alter telemetry protocols.
 * [OpenLog](https://github.com/sparkfun/OpenLog) - With [blackbox](https://github.com/thenickdude/blackbox/) firmware for blackbox data recorder (today usually part of main FC).
 


### PR DESCRIPTION
## What is FPVtune?

[FPVtune](https://fpvtune.com) is a free, open-source automatic PID tuning tool for FPV drones. It reads Betaflight blackbox logs and generates optimized PID/filter settings — saving pilots hours of manual tuning and test flights.

**Repository:** https://github.com/chugzb/betaflight-pid-autotuning

## Why add it?

- Fits naturally in the **Telemetry & Logs 📊** section alongside PID-Analyzer and other blackbox tools
- Open source (MIT license) and free to use
- Actively maintained
- Solves a real pain point: Betaflight has no built-in autotune (unlike some other flight controllers)
- Compatible with Betaflight and INAV flight controllers
- Works with freestyle, racing, cinewhoops, and tiny whoops

## Placement

Added after PID-Analyzer, as both tools analyze blackbox data for PID optimization. FPVtune takes it a step further with automatic tuning recommendations.